### PR TITLE
Removed console.log from line 36

### DIFF
--- a/src/utils/paginate.js
+++ b/src/utils/paginate.js
@@ -33,7 +33,6 @@ const pagination = (req,res,model)=>{
       results.pages = totalPages
       results.limit = limit;
       results.currentPage = page;
-      console.log(results)
       results.results = Object.fromEntries(Object.entries(model).slice(startIndex,lastIndex));
       return results;
   }


### PR DESCRIPTION
For issue #132. Removed `console.log(results)` from line 36 as requested.

Thanks for the excellent documentation of the issue, making it a breeze to navigate and understand!