### PR TITLE
Changed replaceAll() to replace()

### DIFF
--- a/src/utils/filterKeyword.js
+++ b/src/utils/filterKeyword.js
@@ -4,5 +4,5 @@
  * @returns string where space is replaced by %20
  */
 module.exports = function filterKeyword(keyword) {
-  return keyword.replaceAll(/\s/g, '%20');
+  return keyword.replace(/\s/g, '%20');
 };


### PR DESCRIPTION
In reference to issue #138. `replaceAll()` isn't working with our current version of node. Changed `replaceAll()` to `replace()`. The original regex allows for the same functionality of `replaceAll()` 