### PR TITLE
Added capitalization functionality to keywords

### DIFF
--- a/src/data/keywords.js
+++ b/src/data/keywords.js
@@ -1,5 +1,6 @@
-//List of keywords
-module.exports = keywords = [
+// List of keywords.
+// Keep first letter lowercase.
+let keywords = [
   'green energy',
   'energy price',
   'energy prices',
@@ -16,3 +17,19 @@ module.exports = keywords = [
   'gas prices', //new
   'petrol prices', //new
 ];
+
+capitalizeKeywords()
+
+// Capitalizes the first letter of each keyword, and adds it to the list of keywords.
+function capitalizeKeywords() {
+  let newKeywords = []
+
+  for(key of keywords) {
+    let newKey = key[0].toUpperCase() + key.slice(1);
+    newKeywords.push(newKey);
+  }
+  
+  keywords = keywords.concat(newKeywords)
+}
+
+module.exports = keywords;


### PR DESCRIPTION
In reference to issue #102. After comments from @MizouziE on the issue, I decided to keep the keywords we have. The solution I came up with was adding a function to `keywords.js` that capitalizes the first letter of each keyword, and adds it to the `keywords` array.

I wasn't sure if I should have added this functionality to `getDataFromCheerio.js` but it made more sense to me to put it in `keywords.js`, please let me know if this is acceptable.

Also I updated the comments to reflect the changes and their format to suit.

I would recommend we take a close look at the "energy" keyword, and see if we can remove it. As @MizouziE mentioned at one point we were getting off topic articles that use "energy" in terms of food etc.