### PR TITLE
remove twitter route

### DIFF
--- a/src/routes/api/twitter.js
+++ b/src/routes/api/twitter.js
@@ -2,6 +2,6 @@ const express = require('express');
 const controller = require('../../controller/api/twitterAPIController');
 const router = express.Router();
 
-router.get('/', controller.getTwitterAccounts);
+// router.get('/', controller.getTwitterAccounts);
 
 module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,7 @@ function createServer() {
   app.use(express.static('public'));
   app.use('/', main);
   app.use('/api/news', apiNews);
-  app.use('/api/twitter', apiTwitter);
+//  app.use('/api/twitter', apiTwitter);
   app.use((req, res, next) => {
     res.status(404).sendFile(path.resolve('./src/views/not-found.html'));
   });


### PR DESCRIPTION
I have noticed more frequent local crashes due to this endpoint still being active.

As a temporary solution until we incorporate the twitter API, I have commented it out to hopefully prevent it causing problems.

Is this going to be enough, or should the controller be taken  out also?