### PR TITLE
add method to dive into single article url and extract image

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -8,6 +8,7 @@ module.exports = {
           <meta charset="UTF-8">
           <meta http-equiv="X-UA-Compatible" content="IE=edge">
           <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <meta property="og:image" content="https://www.telegraph.co.uk/bills-and-utilities/renewable-energy/" />
           <title>Mock Data</title>
         </head>
         <body>

--- a/src/data/sources.json
+++ b/src/data/sources.json
@@ -104,7 +104,7 @@
   {
     "name": "The Economist",
     "site": "https://www.economist.com/",
-    "base": "https://www.economist.com/",
+    "base": "https://www.economist.com",
     "region": "Europe"
   }
 ]

--- a/src/data/sources.json
+++ b/src/data/sources.json
@@ -8,7 +8,7 @@
   {
     "name": "The Times",
     "site": "https://www.thetimes.co.uk/environment",
-    "base": "https://12ft.io/https://www.thetimes.co.uk",
+    "base": "https://12ft.io/",
     "region": "Europe"
   },
   {
@@ -86,7 +86,7 @@
   {
     "name": "The Economic Times",
     "site": "https://economictimes.indiatimes.com/industry/energy",
-    "base": "https://economictimes.indiatimes.com/",
+    "base": "https://economictimes.indiatimes.com",
     "region": "Asia"
   },
   {

--- a/src/utils/getArticles.js
+++ b/src/utils/getArticles.js
@@ -2,10 +2,9 @@ const axios = require('axios');
 const sources = require('../data/sources.json');
 const sc = require('short-crypt');
 const getDataFromCheerio = require('./getDataFromCheerio');
+const getImage = require('./getImage');
 
 async function getArticles() {
-    const defaultImage =
-        'https://raw.githubusercontent.com/MizouziE/energy-prices-api/master/public/img/energy-prices-api-socials.png';
     let articles = {};
 
     sources.forEach(async (source) => {
@@ -14,21 +13,24 @@ async function getArticles() {
             const returnedArticles = getDataFromCheerio(response.data);
 
             returnedArticles.forEach(async (returned) => {
+                const key = new sc(returned.url)
+                    .encryptToQRCodeAlphanumeric(returned.url)
+                    .slice(0, 10)
+        
                 // now we have an array of multiple article's data to iterate through
                 articles[
-                    new sc(returned.url)
-                        .encryptToQRCodeAlphanumeric(returned.url)
-                        .slice(0, 10)
-                ] = {
+                    key
+                    ] = {
                     // use short-crypt to "hash" the url which works as unique ID
                     title: returned.title,
                     url: source.base + returned.url,
                     source: source.name,
-                    image: /^((http|https):\/\/)/.test(returned.image)
-                        ? returned.image
-                        : defaultImage,
                     region: source.region,
                 };
+
+                const articleUrl = Object.getOwnPropertyDescriptor(articles[key], 'url')
+
+                articles[key] = { ...articles[key], image: await getImage(articleUrl.value) }
             });
         } catch (error) {
             console.log({ error });

--- a/src/utils/getImage.js
+++ b/src/utils/getImage.js
@@ -10,7 +10,6 @@ async function getImage(url) {
     } else if (url.indexOf('http') !== url.lastIndexOf('http') 
         || url.match(/:\/\//) === null) {
 
-        console.log(`Tripped on ${url}`)
         return defaultImage;
 
     }

--- a/src/utils/getImage.js
+++ b/src/utils/getImage.js
@@ -1,4 +1,4 @@
-const { default: axios } = require("axios");
+const axios = require("axios");
 const cheerio = require("cheerio");
 const defaultImage = 'https://energy-price-news.nosweat.cloud/img/energy-prices-api-socials.png'
 

--- a/src/utils/getImage.js
+++ b/src/utils/getImage.js
@@ -1,0 +1,29 @@
+const { default: axios } = require("axios");
+const cheerio = require("cheerio");
+const defaultImage = 'https://energy-price-news.nosweat.cloud/img/energy-prices-api-socials.png'
+
+async function getImage(url) {
+    if (/^(https:\/\/12ft.io\/)/.test(url)) {
+
+        url = url.slice(16);
+
+    } else if (url.indexOf('http') !== url.lastIndexOf('http') 
+        || url.match(/:\/\//) === null) {
+
+        console.log(`Tripped on ${url}`)
+        return defaultImage;
+
+    }
+    const response = await axios.get(url);
+    const $ = cheerio.load(response.data);
+
+    image = $('head').find('meta[property="og:image"]').attr('content');
+
+    if (typeof image !== "undefined") {
+        return image;
+    }
+
+    return defaultImage;
+}
+
+module.exports = getImage;


### PR DESCRIPTION
Also tidied up sources a little

## What type of PR is this? (check all applicable)

- [x] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test

## Description

The `og:image`s from the individual articles meta tags are given in the article object rather than the generic "whole site" ones.

## Fixes issue

Closes #79 

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help
@TAKANOME-DEV , from what I've read it is to do with the level of mocking happening in the mocks. As I added a deeper level of axios call, I need to reflect that in the mock, but haven't managed to yet if you have any suggestions it would be greatly appreciated!

## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed